### PR TITLE
fix: remove resume from url path

### DIFF
--- a/tools/render_template.py
+++ b/tools/render_template.py
@@ -15,7 +15,7 @@ def mock_url_for(endpoint, **kwargs):
     """
     if endpoint == "static":
         filename = kwargs.get("filename", "")
-        return f"/resume/static/{filename}"
+        return f"/static/{filename}"
     return f"/{endpoint}"
 
 


### PR DESCRIPTION
 - update mock to remove `/resume` from URL path